### PR TITLE
Use legal and letter page size ratio to test, rather than hardcoded height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# legal-letter-pdf-splitter
+# legal-letter-pdf-separator
 This Python script will take an input PDF and split it into two PDFs by legal and letter size.
 
 ## Install
@@ -11,7 +11,7 @@ pip install -r requirements.txt
 
 ## Usage
 ```
-usage: page_splitter.py [-h] [--letter_pdf LETTER_PDF] [--legal_pdf LEGAL_PDF] source_pdf
+usage: page_separator.py [-h] [--letter_pdf LETTER_PDF] [--legal_pdf LEGAL_PDF] source_pdf
 
 Splits a PDF into two PDFs by letter and legal page size.
 

--- a/page_separator.py
+++ b/page_separator.py
@@ -19,9 +19,9 @@ class PageType(Enum):
 
 def page_type(page: PageObject) -> PageType:
     ratio = page.mediaBox.getHeight() / page.mediaBox.getWidth()
-    if abs(LETTER_RATIO - ratio) < MARGIN_OF_ERROR:
+    if abs(1 - ratio/LETTER_RATIO) < MARGIN_OF_ERROR:
         return PageType.LETTER
-    elif abs(LEGAL_RATIO - ratio) < MARGIN_OF_ERROR:
+    elif abs(1 - ratio/LEGAL_RATIO) < MARGIN_OF_ERROR:
         return PageType.LEGAL
     return PageType.UNKNOWN
 

--- a/page_separator.py
+++ b/page_separator.py
@@ -8,6 +8,8 @@ from PyPDF2.pdf import PageObject
 LETTER_RATIO = 11 / 8.5
 LEGAL_RATIO = 14 / 8.5
 MARGIN_OF_ERROR = 0.05 # page ratio should differ by at most this percent
+if MARGIN_OF_ERROR >= 0.12:
+    sys.exit("MARGIN_OF_ERROR is too large! page type detection will overlap")
 
 class PageType(Enum):
     UNKNOWN = 0

--- a/page_separator.py
+++ b/page_separator.py
@@ -17,9 +17,9 @@ class PageType(Enum):
 
 def page_type(page: PageObject) -> PageType:
     ratio = page.mediaBox.getHeight() / page.mediaBox.getWidth()
-    if LETTER_RATIO*(1-MARGIN_OF_ERROR) < ratio < LETTER_RATIO*(1+MARGIN_OF_ERROR):
+    if abs(LETTER_RATIO - ratio) < MARGIN_OF_ERROR:
         return PageType.LETTER
-    elif LEGAL_RATIO*(1-MARGIN_OF_ERROR) < ratio < LEGAL_RATIO*(1+MARGIN_OF_ERROR):
+    elif abs(LEGAL_RATIO - ratio) < MARGIN_OF_ERROR:
         return PageType.LEGAL
     return PageType.UNKNOWN
 


### PR DESCRIPTION
Previously `is_letter` just tested to see if height was 720px. Updated the logic to test if the page size height-width ratio is close to legal or letter, with a margin for error. This will make our code a bit more robust if the height doesn't match exactly.

Also renamed to `legal-letter-pdf-separator` instead of splitter.